### PR TITLE
Bump to MUFFET_VERSION 2.4.1 with --rate-limit feature.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL "com.github.actions.description"="Check broken links on web pages stored l
 LABEL "com.github.actions.icon"="list"
 LABEL "com.github.actions.color"="blue"
 
-ENV MUFFET_VERSION="2.3.2"
+ENV MUFFET_VERSION="2.4.1"
 #ENV MUFFET_VERSION="latest"
 
 ENV CADDY_VERSION="2.3.0"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -Eeuo pipefail
 
-export MUFFET_VERSION="2.3.2"
+export MUFFET_VERSION="2.4.1"
 export CADDY_VERSION="2.3.0"
 
 # Command line parameters for muffet


### PR DESCRIPTION
This change set bumps [Muffet to 2.4.1](https://github.com/raviqqe/muffet/releases/tag/v2.4.1), which was just released and includes a `--rate-limit` arg.