### PR TITLE
fix: correct lychee ignore pattern for tokenized remote

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,3 +1,2 @@
 (http|https)://my-testing-domain\.com/
-# Tokenized git remote used to push tags in release-please.yml
-https://x-access-token:.*@github\.com
+https://x-access-token/


### PR DESCRIPTION
## What

Correct the `.lycheeignore` entry for the tokenized git remote used in `release-please.yml`.

## Why

PR #195 merged a narrowed pattern `https://x-access-token:.*@github\.com`, but lychee parses the workflow string `https://x-access-token:${GH_TOKEN}@github.com/...` and extracts it as `https://x-access-token/` (the `${GH_TOKEN}` is not a valid URL char). The narrowed pattern therefore no longer matches, and the link check fails on `main`:

```
[ERROR] https://x-access-token/ (at 62:23) | Connection failed
```

This matches the actual extracted host instead.